### PR TITLE
Fix: guardar preferencias al registrarse y actualizar header según usuario

### DIFF
--- a/front-I-Wellness/src/app/app.component.ts
+++ b/front-I-Wellness/src/app/app.component.ts
@@ -29,6 +29,12 @@ export class AppComponent {
   showFooter: boolean = false;
 
   constructor(private router: Router) {
+
+    if (!sessionStorage.getItem('sessionStarted')) {
+      localStorage.removeItem('rol');
+      sessionStorage.setItem('sessionStarted', 'true');
+    }
+    
     this.router.events.subscribe((event) => {
       if (event instanceof NavigationEnd) {
         // Obtener el rol almacenado en el localStorage


### PR DESCRIPTION
##Descripcion

- Se solucionó el problema que impedía guardar las preferencias del turista tras el registro.
- El header ahora se actualiza dinámicamente dependiendo del tipo de usuario autenticado.
