### PR TITLE
feat: agregar selección de preferencias a servicios (mínimo 2, máximo 5)

### DIFF
--- a/front-I-Wellness/src/app/features/preferencias/services/servicioXpreferencias/servicio-xpreferencia.service.ts
+++ b/front-I-Wellness/src/app/features/preferencias/services/servicioXpreferencias/servicio-xpreferencia.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -10,6 +10,14 @@ export class ServicioXPreferenciaService {
 
   constructor(private http: HttpClient) { }
 
+    // Método para obtener las cabeceras con el token
+    private obtenerHeaders(): HttpHeaders {
+      const token = localStorage.getItem('token');
+      return new HttpHeaders({
+        'Authorization': token ? `Bearer ${token}` : ''
+      });
+    }
+
   // Obtener todos los servicios de preferencia
   obtenerTodos(): Observable<any> {
     return this.http.get<any>(`${this.apiUrl}/all`);
@@ -17,7 +25,8 @@ export class ServicioXPreferenciaService {
 
   // Crear una nueva relación de servicio x preferencia
   crear(servicioXPreferencia: any): Observable<any> {
-    return this.http.post<any>(`${this.apiUrl}/crear`, servicioXPreferencia);
+    const headers = this.obtenerHeaders();
+    return this.http.post<any>(`${this.apiUrl}/crear`, servicioXPreferencia, { headers });
   }
 
   // Actualizar una relación de servicio x preferencia
@@ -40,8 +49,10 @@ export class ServicioXPreferenciaService {
     return this.http.get<any>(`${this.apiUrl}/preferencia/${idPreferencia}`);
   }
 
-  // Eliminar todas las relaciones de preferencia por un servicio
-  eliminarPreferenciasPorServicio(idServicio: number): Observable<any> {
-    return this.http.delete<any>(`${this.apiUrl}/eliminarPorServicio/${idServicio}`);
-  }
+// Eliminar todas las relaciones de preferencia por un servicio
+eliminarPreferenciasPorServicio(idServicio: number): Observable<any> {
+  return this.http.delete<any>(`${this.apiUrl}/eliminarPorServicio/${idServicio}`, {
+    responseType: 'text' as 'json'  
+  });
+}
 }

--- a/front-I-Wellness/src/app/features/users/proveedor/agregar-servicio/agregar-servicio.component.css
+++ b/front-I-Wellness/src/app/features/users/proveedor/agregar-servicio/agregar-servicio.component.css
@@ -175,6 +175,11 @@ label {
     background-color: #3B8E8E;
 }
 
+.save-btn:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
+
 .days-selection {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(20%, 1fr)); 
@@ -187,4 +192,49 @@ label {
     display: flex;
     align-items: center;
     gap: 5px; 
+}
+
+.preferencias-section {
+    margin-top: 20px;
+}
+
+.preferencias-section h3 {
+    font-size: 16px;
+    margin-bottom: 10px;
+    color: #3166A6;
+    font-weight: bold;
+}
+
+.preferencias-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.preferencias-list label {
+    display: flex;
+    align-items: center;
+    background-color: #f6f3eb;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    font-size: 14px;
+    color: #333;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.preferencias-list label:hover {
+    background-color: #e6e2d8;
+}
+
+.preferencias-list input[type="checkbox"] {
+    margin-right: 8px;
+    accent-color: #3166A6; /* Para navegadores modernos */
+}
+
+.error-message {
+    color: red;
+    font-size: 12px;
+    margin-top: 5px;
 }

--- a/front-I-Wellness/src/app/features/users/proveedor/agregar-servicio/agregar-servicio.component.html
+++ b/front-I-Wellness/src/app/features/users/proveedor/agregar-servicio/agregar-servicio.component.html
@@ -1,5 +1,4 @@
 <body>
-
     <div class="container">
         <div class="form-box">
             <h2>Nuevo servicio</h2>
@@ -11,30 +10,52 @@
                     </label>
                     <input id="imageInput" type="file" (change)="onImageSelected($event)" accept="image/*" hidden>
                   </div>
-                <div class="form-fields">
-                    <input type="text" placeholder="Nombre" [(ngModel)]="nuevoServicio.nombre">
-                    <textarea placeholder="Descripción" [(ngModel)]="nuevoServicio.descripcion"></textarea>
-
-                     <!-- Selección de días -->
-                     <label for="days">Horarios disponibles:</label>
-                    <div class="days-selection">
-                        <div class="day-item" *ngFor="let day of days">
-                            <input type="checkbox" [(ngModel)]="day.selected" id="{{ day.name }}">
-                            <label for="{{ day.name }}">{{ day.name }}</label>
-                        </div>
-                    </div>
-
-                    <!-- Horario -->
-                    <div class="time-selection">
-                        <label for="starTime">Hora de apertura:</label>
-                        <input type="time" id="startTime"[(ngModel)]="startTime">
-                        <label for="endTime">Hora de cierre:</label>
-                        <input type="time" id="endTime" [(ngModel)]="endTime">
-                    </div>
+                  <div class="form-fields">
+                    <input type="text" placeholder="Nombre" [(ngModel)]="nuevoServicio.nombre" required>
                     
-                    <input type="number" placeholder="Precio" [(ngModel)]="nuevoServicio.precio"> 
+                    <textarea placeholder="Descripción" [(ngModel)]="nuevoServicio.descripcion" required></textarea>
+                  
+                    <!-- Horario -->
+                    <label>Horarios disponibles:</label>
+                    <div class="days-selection">
+                      <div class="day-item" *ngFor="let day of days">
+                        <input type="checkbox" [(ngModel)]="day.selected" id="{{ day.name }}">
+                        <label for="{{ day.name }}">{{ day.name }}</label>
+                      </div>
+                    </div>
+                  
+                    <div class="time-selection">
+                      <label>Hora de apertura:</label>
+                      <input type="time" [(ngModel)]="startTime" required>
+                      <label>Hora de cierre:</label>
+                      <input type="time" [(ngModel)]="endTime" required>
+                    </div>
+                  
+                    <!-- Precio -->
+                    <label>Precio:</label>
+                    <input type="number" placeholder="Ingresa el precio o 0 si es gratuito" [(ngModel)]="nuevoServicio.precio" required>
+                  
+                    <!-- Preferencias -->
+                    <div class="preferencias-section">
+                      <h3>Selecciona tus preferencias <span style="font-weight: normal;">(mínimo 2, máximo 5)</span>:</h3> 
+                      <div class="preferencias-list">
+                        <label *ngFor="let pref of preferencias">
+                          <input
+                            type="checkbox"
+                            [value]="pref._idPreferencias"
+                            [checked]="selectedPreferences.includes(pref._idPreferencias)"
+                            (change)="onPreferenceChange($event, pref._idPreferencias)"
+                            [disabled]="
+                              !selectedPreferences.includes(pref._idPreferencias) && selectedPreferences.length >= 5
+                            ">
+                          {{ pref.nombre }}
+                        </label>
+                      </div>
+                    </div>
+                  
+                    <!-- Botón -->
                     <button class="save-btn" (click)="guardarServicio()">Guardar</button>
-                </div>
+                  </div>
             </div>
         </div>
     </div>

--- a/front-I-Wellness/src/app/features/users/proveedor/editar-servicio/editar-servicio.component.css
+++ b/front-I-Wellness/src/app/features/users/proveedor/editar-servicio/editar-servicio.component.css
@@ -143,3 +143,48 @@ textarea {
     align-items: center;
     gap: 5px; 
 }
+
+.preferencias-section {
+    margin-top: 20px;
+}
+
+.preferencias-section h3 {
+    font-size: 16px;
+    margin-bottom: 10px;
+    color: #3166A6;
+    font-weight: bold;
+}
+
+.preferencias-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.preferencias-list label {
+    display: flex;
+    align-items: center;
+    background-color: #f6f3eb;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    font-size: 14px;
+    color: #333;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.preferencias-list label:hover {
+    background-color: #e6e2d8;
+}
+
+.preferencias-list input[type="checkbox"] {
+    margin-right: 8px;
+    accent-color: #3166A6; /* Para navegadores modernos */
+}
+
+.error-message {
+    color: red;
+    font-size: 12px;
+    margin-top: 5px;
+}

--- a/front-I-Wellness/src/app/features/users/proveedor/editar-servicio/editar-servicio.component.html
+++ b/front-I-Wellness/src/app/features/users/proveedor/editar-servicio/editar-servicio.component.html
@@ -1,40 +1,73 @@
-    <body>
-        <div class="container">
-            <div class="form-box">
-                <h2>Editar servicio</h2>
-                <div class="form-content" *ngIf="servicio">
-                    <div class="image-upload">
-                        <label for="fileInput" class="image-label"  >
-                            <img [src]="servicio.imagen" alt="{{ servicio.nombre }}">
-                            <p class="upload-text">Agregar imagen</p>
-                        </label>
-                        <input type="file" id="fileInput" (change)="onFileSelected($event)" hidden accept="image/*">
-                    </div>
-                    <div class="form-fields">
-                        <input type="text" value="{{ servicio.nombre }}" [(ngModel)]="servicio.nombre">
-                        
-                        <!-- Selección de días -->
-                        <label for="days">Horarios disponibles:</label>
-                        <div class="days-selection">
-                            <div class="day-item" *ngFor="let day of days">
-                                <input type="checkbox" [(ngModel)]="day.selected" id="{{ day.name }}">
-                                <label for="{{ day.name }}">{{ day.name }}</label>
-                            </div>
-                        </div>
+<body>
+    <div class="container">
+        <div class="form-box">
+            <h2>Editar servicio</h2>
+            <div class="form-content" *ngIf="servicio">
+                <!-- Imagen -->
+                <div class="image-upload">
+                    <label for="fileInput" class="image-label">
+                        <img [src]="servicio.imagen" alt="{{ servicio.nombre }}">
+                        <p class="upload-text">Agregar imagen</p>
+                    </label>
+                    <input type="file" id="fileInput" (change)="onFileSelected($event)" hidden accept="image/*">
+                </div>
 
-                        <!-- Horario -->
-                        <div class="time-selection">
-                            <label for="starTime">Hora de apertura:</label>
-                            <input type="time" id="startTime"[(ngModel)]="startTime">
-                            <label for="endTime">Hora de cierre:</label>
-                            <input type="time" id="endTime" [(ngModel)]="endTime">
+                <!-- Campos del formulario -->
+                <div class="form-fields">
+
+                    <!-- Nombre del servicio -->
+                    <label for="nombre">Nombre del servicio:</label>
+                    <input id="nombre" type="text" value="{{ servicio.nombre }}" [(ngModel)]="servicio.nombre">
+
+                    <!-- Descripción -->
+                    <label for="descripcion">Descripción:</label>
+                    <textarea id="descripcion" [(ngModel)]="servicio.descripcion">{{ servicio.descripcion }}</textarea>
+
+                    <!-- Selección de días -->
+                    <label>Horarios disponibles (días):</label>
+                    <div class="days-selection">
+                        <div class="day-item" *ngFor="let day of days">
+                            <input type="checkbox" [(ngModel)]="day.selected" id="{{ day.name }}">
+                            <label for="{{ day.name }}">{{ day.name }}</label>
                         </div>
-                        <label for="precio">Precio:</label>
-                        <input id="precio" type="number" value="{{ servicio.precio }}" [(ngModel)]="servicio.precio">
-                        <textarea [(ngModel)]="servicio.descripcion">{{ servicio.descripcion }}</textarea>
-                        <button class="save-btn" (click)="navigateTo()" (click)="getFormattedSchedule()">Guardar</button>
                     </div>
+
+                    <!-- Horario -->
+                    <div class="time-selection">
+                        <label for="startTime">Hora de apertura:</label>
+                        <input type="time" id="startTime" [(ngModel)]="startTime">
+
+                        <label for="endTime">Hora de cierre:</label>
+                        <input type="time" id="endTime" [(ngModel)]="endTime">
+                    </div>
+
+                    <!-- Precio -->
+                    <label for="precio">Precio:</label>
+                    <input id="precio" type="number" value="{{ servicio.precio }}" [(ngModel)]="servicio.precio">
+
+                    <!-- Preferencias -->
+                    <div class="preferencias-section">
+                        <h3>Selecciona tus preferencias <span style="font-weight: normal;">(mínimo 2, máximo 5)</span>:</h3>
+                        <div class="preferencias-list">
+                            <label *ngFor="let pref of preferencias">
+                                <input
+                                    type="checkbox"
+                                    [value]="pref._idPreferencias"
+                                    [checked]="selectedPreferences.includes(pref._idPreferencias)"
+                                    (change)="onPreferenceChange($event, pref._idPreferencias)"
+                                    [disabled]="
+                                        !selectedPreferences.includes(pref._idPreferencias) &&
+                                        selectedPreferences.length >= 5
+                                    ">
+                                {{ pref.nombre }}
+                            </label>
+                        </div>
+                    </div>
+
+                    <!-- Botón guardar -->
+                    <button class="save-btn" (click)="navigateTo(); getFormattedSchedule()">Guardar</button>
                 </div>
             </div>
         </div>
-    </body>
+    </div>
+</body>

--- a/front-I-Wellness/src/app/features/users/proveedor/home-proveedor/home-proveedor.component.html
+++ b/front-I-Wellness/src/app/features/users/proveedor/home-proveedor/home-proveedor.component.html
@@ -13,7 +13,7 @@
                     <div class="service-info">
                         <h3>{{ servicio.nombre }}</h3>
                         <p>{{ servicio.descripcion }}</p>
-                        <p class="price">{{ servicio.precio }} USD</p>
+                        <p class="price">{{ servicio.precio === 0 ? 'Gratis' : servicio.precio + ' USD' }}</p>
                     </div>
                     <div class="service-actions">
                         <button class="visibility-btn" (click)="navigateTo('infoservicio', servicio._idServicio)">👁</button>


### PR DESCRIPTION
## Descripcion
Se implementó una nueva sección en el formulario de edición y de agregar servicios que permite a los usuarios seleccionar sus preferencias asociadas al servicio, con una restricción de selección entre mínimo 2 y máximo 5 opciones.
**Cambios realizados**
- Se agregó un nuevo bloque en la vista que muestra una lista de preferencias disponibles.
- Cada preferencia está representada por un checkbox.
- Se controla la lógica para:
  - Evitar seleccionar más de 5 preferencias.
  - Mantener seleccionadas las preferencias ya guardadas.
- Se enlazó cada preferencia con su respectivo pref._idPreferencias para asegurar su correcta identificación y persistencia.
- Se añadieron mensajes indicativos para el usuario, mejorando la experiencia al seleccionar las preferencias